### PR TITLE
Remove trailing slashes from API end-points

### DIFF
--- a/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/TagController.java
+++ b/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/TagController.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 public class TagController {
     private final ITagService tagService;
 
-    @GetMapping("/")
+    @GetMapping
     public List<DocumentTag> listAll() {
         return tagService.listAll();
     }

--- a/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/TemplateController.java
+++ b/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/TemplateController.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 public class TemplateController {
     private final ITemplateService templateService;
 
-    @GetMapping("/")
+    @GetMapping
     public List<DocumentTemplate> listAll() {
         return templateService.listAll();
     }


### PR DESCRIPTION
This removes the trailing slashes requirement from the API end-points.

I had a more convoluted way of doing by automatically mapping no slash request to `/` requests but I don't think it's worth the complexity of having request handlers if not careful could lead to some very hard to find bugs.

So instead lets stick to the default behaviour of spring boot, and not suffix our end-points and requests with `/`.