### PR TITLE
Use filter to handle CORS

### DIFF
--- a/backend/src/main/java/org/latexscribe/LatexScribe/config/SimpleCorsFilter.java
+++ b/backend/src/main/java/org/latexscribe/LatexScribe/config/SimpleCorsFilter.java
@@ -1,0 +1,31 @@
+package org.latexscribe.LatexScribe.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SimpleCorsFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, PUT, OPTIONS, DELETE, HEAD");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Headers", "x-requested-with, authorization, cache-control, content-type, Origin, key");
+        response.setHeader("Content-Type", "*");
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            response.setStatus(HttpServletResponse.SC_OK);
+        } else {
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/AuthController.java
+++ b/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/AuthController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 
 @RestController
-@CrossOrigin(origins = "*")
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {

--- a/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/DocumentController.java
+++ b/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/DocumentController.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/documents")
 public class DocumentController {

--- a/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/TagController.java
+++ b/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/TagController.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/tags")
 public class TagController {

--- a/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/TemplateController.java
+++ b/backend/src/main/java/org/latexscribe/LatexScribe/webcontroller/TemplateController.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@CrossOrigin(origins = "*")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/templates")
 public class TemplateController {


### PR DESCRIPTION
This PR makes use of request filters to set the correct CORS value which encapsulates the logout API end-point, fixing the error when using logout API.